### PR TITLE
Update replacements in "update-ecs-actions"

### DIFF
--- a/.github/workflows/test-update-ecs-services.yaml
+++ b/.github/workflows/test-update-ecs-services.yaml
@@ -12,12 +12,25 @@ jobs:
     steps:
       - name: Checkout repository code
         uses: actions/checkout@v2
-      - name: Do a dry-run
+      - name: Base case
         uses: ./actions/update-ecs-services
         with:
           aws-access-key-id: "ACCESS_KEY"
           aws-secret-access-key: "SECRET_KEY"
           aws-session-token: "SESSION"
           env-name: "environment"
-          service-names: '["service-1", "service-2", "service-with-an-n"]'
+          service-names: '["service-1","service-2"]'
+          dry-run: true
+      - name: Whitespace in array and N in service names
+        uses: ./actions/update-ecs-services
+        with:
+          aws-access-key-id: "ACCESS_KEY"
+          aws-secret-access-key: "SECRET_KEY"
+          aws-session-token: "SESSION"
+          env-name: "environment"
+          service-names: |
+            [
+              "service-name-1",
+              "service-name-2"
+            ]
           dry-run: true

--- a/actions/update-ecs-services/action.yaml
+++ b/actions/update-ecs-services/action.yaml
@@ -31,9 +31,13 @@ runs:
         patternBracketsAndSpace="[[\] ]"
         patternNewline=$'\n'
         patternComma=","
+        echo $inputs
         tmpBracketsAndSpace="${inputs//${patternBracketsAndSpace}/}"
+        echo $tmpBracketsAndSpace
         tmpNewline="${tmpBrackets//${patternNewline}/}"
+        echo $tmpNewline
         servicesArray="(${tmpNewline//${patternComma}/ })"
+        echo $servicesArray
         
         echo "::set-output name=services::${servicesArray}"
     - name: Update services

--- a/actions/update-ecs-services/action.yaml
+++ b/actions/update-ecs-services/action.yaml
@@ -31,14 +31,10 @@ runs:
         patternBracketsAndSpace="[[\] ]"
         patternNewline=$'\n'
         patternComma=","
-        echo $inputs
         tmpBracketsAndSpace="${inputs//${patternBracketsAndSpace}/}"
-        echo $tmpBracketsAndSpace
         tmpNewline="${tmpBracketsAndSpace//${patternNewline}/}"
-        echo $tmpNewline
         servicesArray="(${tmpNewline//${patternComma}/ })"
-        echo $servicesArray
-        
+
         echo "::set-output name=services::${servicesArray}"
     - name: Update services
       shell: bash

--- a/actions/update-ecs-services/action.yaml
+++ b/actions/update-ecs-services/action.yaml
@@ -34,7 +34,7 @@ runs:
         echo $inputs
         tmpBracketsAndSpace="${inputs//${patternBracketsAndSpace}/}"
         echo $tmpBracketsAndSpace
-        tmpNewline="${tmpBrackets//${patternNewline}/}"
+        tmpNewline="${tmpBracketsAndSpace//${patternNewline}/}"
         echo $tmpNewline
         servicesArray="(${tmpNewline//${patternComma}/ })"
         echo $servicesArray

--- a/actions/update-ecs-services/action.yaml
+++ b/actions/update-ecs-services/action.yaml
@@ -28,10 +28,12 @@ runs:
       shell: bash
       run: |
         inputs='${{inputs.service-names}}'
-        patternBrackets="[[\]\n]"
-        patternComma="[,]"
-        services="(${inputs//${patternBrackets}/})"
-        servicesArray="${services//${patternComma}/ }"
+        patternBracketsAndSpace="[[\] ]"
+        patternNewline=$'\n'
+        patternComma=","
+        tmpBracketsAndSpace="${inputs//${patternBracketsAndSpace}/}"
+        tmpNewline="${tmpBrackets//${patternNewline}/}"
+        servicesArray="(${tmpNewline//${patternComma}/ })"
         
         echo "::set-output name=services::${servicesArray}"
     - name: Update services


### PR DESCRIPTION
Fixes:
* Support newlines in input
* Support "n" in input
* Support spaces in input (but not as part of service names)

Related to https://github.com/telia-company/fft-aws-infrastructure/issues/93